### PR TITLE
Fix Fatal error: Division by zero in remainder operation

### DIFF
--- a/Source/ExpandedLayout.swift
+++ b/Source/ExpandedLayout.swift
@@ -115,25 +115,29 @@ public class ExpandedLayout: UICollectionViewFlowLayout  {
                 let indexPath = IndexPath(row: row, section: section)
                 let itemSize = delegate.collectionView!(collectionView, layout: self, sizeForItemAt: indexPath)
                 let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
-
+                
                 let columnsCount = Int(contentWidth / itemSize.width)
-                let column = row % columnsCount
-                attributes.frame = CGRect(
-                    x: sectionInset.left + CGFloat(column) * (itemSize.width + minimumInteritemSpacing),
-                    y: contentHeight,
-                    width: itemSize.width,
-                    height: itemSize.height
-                )
-
-                attributes.isHidden = false
-                self.itemsAttributes[section].append(attributes)
-
-                if column == columnsCount - 1 || row == numberOfItems - 1 {
-                    self.contentHeight += itemSize.height
-                    if row < numberOfItems - 1 {
-                        contentHeight += minimumLineSpacing
+    
+                if columnsCount > 0 {
+                    let column = row % columnsCount
+                    attributes.frame = CGRect(
+                        x: sectionInset.left + CGFloat(column) * (itemSize.width + minimumInteritemSpacing),
+                        y: contentHeight,
+                        width: itemSize.width,
+                        height: itemSize.height
+                    )
+                    
+                    attributes.isHidden = false
+                    self.itemsAttributes[section].append(attributes)
+                    
+                    if column == columnsCount - 1 || row == numberOfItems - 1 {
+                        self.contentHeight += itemSize.height
+                        if row < numberOfItems - 1 {
+                            contentHeight += minimumLineSpacing
+                        }
                     }
                 }
+                
             }
             self.contentHeight += self.sectionInset.bottom
         }


### PR DESCRIPTION
This fixes `Thread 1: Fatal error: Division by zero in remainder operation` when for some reasons `prepare()` method is called with zero contentWidth. 

I was working on my custom fork where the collectionView should automatically calculate its size based on the Intrinsic content size. Then After awhile I was greeted by the mentioned error. Refer to the screenshot below.


![Screen Shot 2021-02-21 at 1 43 50 PM](https://user-images.githubusercontent.com/25889447/108615832-4261b180-744b-11eb-8075-bd373f19bbc5.jpg)

I fixed the issue by preventing further calculations unless the `columnsCount` is greater than zero.  
So I thought it will be a great addition if it doesn't break any of your calculations. (So far it doesn't break anything based on my use case).
